### PR TITLE
Merge branches 'CorrectStateMachineAccessibility' and 'master' of https://github.com/MontclairRobotics/cyborg into CorrectStateMachineAccessibility

### DIFF
--- a/src/main/java/org/montclairrobotics/cyborg/utils/CBStateMachine.java
+++ b/src/main/java/org/montclairrobotics/cyborg/utils/CBStateMachine.java
@@ -19,7 +19,7 @@ public abstract class CBStateMachine<T> {
 	 * If this state is set to Looping doTransition() and doCurrentState() will be called for each transition, 
 	 * but those transitions will be invisible outside of what this class and any overridden methods do. 
 	 */
-	enum CBStateMachineLoopMode {OneShot, Looping};
+	protected enum CBStateMachineLoopMode {OneShot, Looping};
 	
 	protected CBStateMachine(T start) {
 		setState(start);


### PR DESCRIPTION
This changes the accessibility of CBStateMachineLoopMode to make it accessible to subclasses.